### PR TITLE
Removed admin pages from the load widget routine 

### DIFF
--- a/tawk_to.module
+++ b/tawk_to.module
@@ -40,7 +40,7 @@ function tawk_to_get_widget() {
 function tawk_to_page_build(&$page) {
   $widget = tawk_to_get_widget();
 
-  if ($widget['page_id'] === '' || $widget['widget_id'] === '') {
+  if ($widget['page_id'] === '' || $widget['widget_id'] === '' || strpos(current_path(), 'admin') !== FALSE) {
     return NULL;
   }
 

--- a/views/widget.php.inc
+++ b/views/widget.php.inc
@@ -11,17 +11,17 @@
  * Creates markup for embed script element.
  */
 function tawk_to_render_widget($page_id, $widget_id) {
-  return '<!--Start of Tawk.to Script-->
-  <script type="text/javascript">
-  var $_Tawk_API={},$_Tawk_LoadStart=new Date();
-  (function(){
-  var s1=document.createElement("script"),s0=document.getElementsByTagName("script")[0];
-  s1.async=true;
-  s1.src="https://embed.tawk.to/' . $page_id . '/' . $widget_id . '";
-  s1.charset="UTF-8";
-  s1.setAttribute("crossorigin","*");
-  s0.parentNode.insertBefore(s1,s0);
-  })();
-  </script>
-  <!--End of Tawk.to Script-->';
+  return t('<!--Start of Tawk.to Script-->
+    <script type="text/javascript">
+        var Tawk_API = Tawk_API || {}, Tawk_LoadStart = new Date();
+        (function(){
+            var s1 = document.createElement("script"), s0 = document.getElementsByTagName("script")[0];
+            s1.async = true;
+            s1.src = "https://embed.tawk.to/@p/@w";
+            s1.charset = "UTF-8";
+            s1.setAttribute("crossorigin","*");
+            s0.parentNode.insertBefore(s1,s0);
+        })();
+        <!-- Custom code can go here -->
+    </script><!--End of Tawk.to Script-->', array('@p' => $page_id, '@w' => $widget_id));
 }


### PR DESCRIPTION
I added a third conditional in the load page hook so it ignores the admin pages since the widget seems unnecessary on those pages. I also updated the code for the render widget function and used the t function for the script insertion on the footer.
